### PR TITLE
Add Django 5.1 support

### DIFF
--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -2,7 +2,7 @@
 
 ## Compatibility
 
-`{{ cookiecutter.repo_name }}` is compatible with Python 3.8 - 3.12{% if cookiecutter.is_django == "True" %}, Django 3.2 - 5.0, Psycopg 2 - 3, and Postgres 12 - 16{% endif %}.
+`{{ cookiecutter.repo_name }}` is compatible with Python 3.8 - 3.12{% if cookiecutter.is_django == "True" %}, Django 3.2 - 5.1, Psycopg 2 - 3, and Postgres 12 - 16{% endif %}.
 
 ## Documentation
 

--- a/{{ cookiecutter.repo_name }}/docs/index.md
+++ b/{{ cookiecutter.repo_name }}/docs/index.md
@@ -4,4 +4,4 @@ Welcome to the docs for `{{ cookiecutter.repo_name }}`! It doesn't appear that t
 
 ## Compatibility
 
-`{{ cookiecutter.repo_name }}` is compatible with Python 3.8 - 3.12{% if cookiecutter.is_django == "True" %}, Django 3.2 - 5.0, Psycopg 2 - 3, and Postgres 12 - 16{% endif %}.
+`{{ cookiecutter.repo_name }}` is compatible with Python 3.8 - 3.12{% if cookiecutter.is_django == "True" %}, Django 3.2 - 5.1, Psycopg 2 - 3, and Postgres 12 - 16{% endif %}.

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
   "Framework :: Django :: 4.1",
   "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.0",
+  "Framework :: Django :: 5.1",
   {% endif %}
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",

--- a/{{ cookiecutter.repo_name }}/tox.ini
+++ b/{{ cookiecutter.repo_name }}/tox.ini
@@ -7,6 +7,8 @@ envlist =
     py312-django42-psycopg3
     py{310,311,312}-django50-psycopg2
     py312-django50-psycopg3
+    py{310,311,312}-django51-psycopg2
+    py312-django51-psycopg3
     report
 {%- else %}
 envlist = py{38,39,310,311,312},report
@@ -27,6 +29,7 @@ deps =
     django32: Django>=3.2,<3.3
     django42: Django>=4.2,<4.3
     django50: Django>=5.0rc1,<5.1
+    django51: Django>=5.1rc1,<5.2
     psycopg2: psycopg2-binary
     psycopg3: psycopg[binary]
 commands =
@@ -44,7 +47,7 @@ allowlist_externals =
     coverage
 skip_install = true
 {%- if cookiecutter.is_django == "True" %}
-depends = py{38,39,310,311,312}-django{32,42}-psycopg2,py312-django42-psycopg3-py{310,311,312}-django50-psycopg2-py312-django50-psycopg3
+depends = py{38,39,310,311,312}-django{32,42}-psycopg2py312-django42-psycopg3-py{310,311,312}-django50-psycopg2-py312-django50-psycopg3
 {%- else %}
 depends = py{38,39,310,311,312}
 {%- endif %}


### PR DESCRIPTION
Investigating https://github.com/Opus10/django-pgtrigger/issues/148, I remembered the process to add a new Django version globally.
I looked back at @adamchainz contribution https://github.com/Opus10/python-library-template/pull/13 and adapted it for the last Django version.

Do you also want to remove unsupported Django versions (< 4.2)?