### PR TITLE
Update docker compose calls to version 2

### DIFF
--- a/{{ cookiecutter.repo_name }}/.circleci/config.yml
+++ b/{{ cookiecutter.repo_name }}/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
         docker:
           - image: opus10/circleci-python-library:2024-04-17
             environment:
-              # Ensure makefile commands are not wrapped in "docker-compose run"
+              # Ensure makefile commands are not wrapped in "docker compose run"
               EXEC_WRAPPER: ''
               TOX_PARALLEL_NO_SPINNER: 1
         {%- if cookiecutter.is_django == "True" %}

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -36,7 +36,7 @@ endif
 
 # Docker run mounts the local code directory, SSH (for git), and global git config information
 {%- if cookiecutter.is_django == "True" %}
-DOCKER_RUN_CMD?=$(DOCKER_CMD)-compose run --name $(PACKAGE_NAME) $(DOCKER_RUN_ARGS) -d app
+DOCKER_RUN_CMD?=$(DOCKER_CMD) compose run --name $(PACKAGE_NAME) $(DOCKER_RUN_ARGS) -d app
 {%- else %}
 DOCKER_RUN_CMD?=$(DOCKER_CMD) run -t --name $(PACKAGE_NAME) $(DOCKER_RUN_ARGS) -d opus10/circleci-python-library
 {%- endif %}
@@ -71,7 +71,7 @@ endif
 .PHONY: docker-start
 docker-start:
     {%- if cookiecutter.is_django %}
-	$(DOCKER_CMD)-compose pull
+	$(DOCKER_CMD) compose pull
     {%- else %}
 	$(DOCKER_CMD) pull opus10/circleci-public-python-library
     {%- endif %}
@@ -131,7 +131,7 @@ docker-setup: docker-teardown docker-start lock dependencies git-setup
 .PHONY: docker-teardown
 docker-teardown:
     {%- if cookiecutter.is_django == "True" %}
-	$(DOCKER_CMD)-compose down --remove-orphans
+	$(DOCKER_CMD) compose down --remove-orphans
     {%- else %}
 	-$(DOCKER_CMD) stop $(PACKAGE_NAME)
 	-$(DOCKER_CMD) rm $(PACKAGE_NAME)


### PR DESCRIPTION
Update docker compose call to version 2

> **From July 2023** Compose V1 stopped receiving updates. It’s also **no longer available in new releases of Docker Desktop**.

> Compose V2, which was **first released in 2020**, is included with all currently supported versions of Docker Desktop. It offers an improved CLI experience, improved build performance with BuildKit, and continued new-feature development.

https://docs.docker.com/compose/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2